### PR TITLE
Change target to static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 .nuxt
+dist

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,7 @@
 import serveStatic from "serve-static";
 export default {
   // Global page headers: https://go.nuxtjs.dev/config-head
+  target: 'static',
   server: {
     port: 3000,
     host: "localhost"


### PR DESCRIPTION
Run `npm run generate` to build a static website with `index.html` entrypoint